### PR TITLE
Switch from flask.Markup to MarkupSafe

### DIFF
--- a/flask_fomanticui/core.py
+++ b/flask_fomanticui/core.py
@@ -29,7 +29,9 @@ Implementation of Fomantic UI in Flask.
 
 import warnings
 
-from flask import Blueprint, Markup, current_app, url_for
+from flask import Blueprint, current_app, url_for
+
+from markupsafe import Markup
 
 try:  # pragma: no cover
     from wtforms.fields import HiddenField

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ from setuptools import setup  # noqa
 PATH = pathlib.Path(os.path.abspath(os.path.dirname(__file__)))
 
 
-REQUIREMENTS = ["Flask>=2.0.2"]
+REQUIREMENTS = ["Flask>=2.3.0", "markupsafe"]
 
 with open(PATH / "flask_fomanticui" / "__init__.py") as fp:
     for line in fp.readlines():


### PR DESCRIPTION
[Flask 2.3.0](https://flask.palletsprojects.com/en/3.0.x/changes/#version-2-3-0) deprecated its Markup class in favor of of MarkupSafe.  This causes an import error when using Flask-FomanticUI with newer Flask releases.

Fixes juniors90/Flask-FomanticUI#3